### PR TITLE
remove weights for surveys other than participants

### DIFF
--- a/R/contact_matrix.r
+++ b/R/contact_matrix.r
@@ -38,8 +38,6 @@
 #' @author Sebastian Funk
 contact_matrix <- function(survey, countries = c(), survey.pop, age.limits, filter, n = 1, bootstrap, counts = FALSE, symmetric = FALSE, split = FALSE, estimated.participant.age = c("mean", "sample", "missing"), estimated.contact.age = c("mean", "sample", "missing"), missing.participant.age = c("remove", "keep"), missing.contact.age = c("remove", "sample", "keep", "ignore"), weights = c(), weigh.dayofweek = FALSE, weigh.age = FALSE, weight.threshold = NA, sample.all.age.groups = FALSE, return.part.weights = FALSE, return.demography = NA, per.capita = FALSE, ...) {
 
-  age.group <- NULL
-
   surveys <- c("participants", "contacts")
 
   dot.args <- list(...)

--- a/R/contact_matrix.r
+++ b/R/contact_matrix.r
@@ -462,33 +462,31 @@ contact_matrix <- function(survey, countries = c(), survey.pop, age.limits, filt
 
   ## assign weights to participants, to account for age variation
   if (weigh.age) {
-    if ("age.group" %in% colnames(survey$participants)) {
       # get number and proportion of participants by age
-      survey$participants[, age.count := .N, by = eval(columns[["participant.age"]])]
-      survey$participants[, age.proportion := age.count / .N]
+    survey$participants[, age.count := .N, by = eval(columns[["participant.age"]])]
+    survey$participants[, age.proportion := age.count / .N]
 
-      # get reference population by age (absolute and proportional)
-      part.age.all <- range(unique(survey$participants[, get(columns[["participant.age"]])]))
-      survey.pop.detail <- data.table(pop_age(survey.pop.full, seq(part.age.all[1], part.age.all[2] + 1)))
-      names(survey.pop.detail) <- c(columns[["participant.age"]], "population.count")
-      survey.pop.detail[, population.proportion := population.count / sum(population.count)]
+    # get reference population by age (absolute and proportional)
+    part.age.all <- range(unique(survey$participants[, get(columns[["participant.age"]])]))
+    survey.pop.detail <- data.table(pop_age(survey.pop.full, seq(part.age.all[1], part.age.all[2] + 1)))
+    names(survey.pop.detail) <- c(columns[["participant.age"]], "population.count")
+    survey.pop.detail[, population.proportion := population.count / sum(population.count)]
 
-      # merge reference and survey population data
-      survey$participants <- merge(survey$participants, survey.pop.detail, by = eval(columns[["participant.age"]]))
+    # merge reference and survey population data
+    survey$participants <- merge(survey$participants, survey.pop.detail, by = eval(columns[["participant.age"]]))
 
-      # calculate age-specific weights
-      survey$participants[, weight.age := population.proportion / age.proportion]
+    # calculate age-specific weights
+    survey$participants[, weight.age := population.proportion / age.proportion]
 
-      # merge 'weight.age' into 'weight'
-      survey$participants[, weight := weight * weight.age]
+    # merge 'weight.age' into 'weight'
+    survey$participants[, weight := weight * weight.age]
 
-      ## Remove the additional columns
-      survey$participants[, age.count := NULL]
-      survey$participants[, age.proportion := NULL]
-      survey$participants[, population.count := NULL]
-      survey$participants[, population.proportion := NULL]
-      survey$participants[, weight.age := NULL]
-    }
+    ## Remove the additional columns
+    survey$participants[, age.count := NULL]
+    survey$participants[, age.proportion := NULL]
+    survey$participants[, population.count := NULL]
+    survey$participants[, population.proportion := NULL]
+    survey$participants[, weight.age := NULL]
   }
 
   ## further weigh if columns are specified


### PR DESCRIPTION
Currently, weights are applied to both participants and contacts. However, it is not clear if weights for contacts make sense. They are not documented, not mentioned in the vignette, and at the very least would need an option to check if a user would want weights applied to contacts.

This PR removes weights for any survey but the participant survey. For the day of the week, for example, this means that weights can be applied to correct for an imbalanced representation in weekdays/weekends amongst when participant completed their survey, but no further weighting is applied to contacts based on the day on which the contact occurred.

If there is ever a use case where weights are to be applied to contacts, this could and should be re-implemented in a clearer way. For now, I think they are better removed.

Fixes #40 and reverts #44.

The diff highlights quite a few changes but most of them are changed indentation because `for` statements have been removed.