### PR TITLE
Match country by UN codes rather than country name

### DIFF
--- a/R/lists.r
+++ b/R/lists.r
@@ -65,11 +65,11 @@ wpp_countries <- function() {
   popF <- fread(system.file("data", "popF.txt", package = "wpp2017"))
   popM <- fread(system.file("data", "popM.txt", package = "wpp2017"))
 
-  countries <- unique(c(popF$name, popM$name))
+  countries <- unique(c(popF$country_code, popM$country_code))
   found_countries <-
     suppressWarnings(countrycode::countrycode(
       countries,
-      "country.name",
+      "un",
       "country.name"
     ))
   found_countries <- found_countries[!is.na(found_countries)]

--- a/R/wpp_age.r
+++ b/R/wpp_age.r
@@ -41,7 +41,7 @@ wpp_age <- function(countries, years) {
 
   if (!missing(countries)) {
     ## match by UN country code
-    pop <- suppressWarnings(pop[country_code %in% countrycode(countries, "country.name", "iso3n")])
+    pop <- suppressWarnings(pop[country_code %in% countrycode(countries, "country.name", "un")])
   }
 
   if (nrow(pop) > 0) {


### PR DESCRIPTION
This should be much faster because it uses a dictionary instead of a regex-based approach.

It is also more robust because the previous approach was mapping "Less developed regions, excluding China" to "China".