### PR TITLE
Simplify `load_survey()` and fix out-of-memory issues

### DIFF
--- a/R/load_survey.r
+++ b/R/load_survey.r
@@ -85,30 +85,22 @@ load_survey <- function(files, ...) {
           all.x = TRUE, allow.cartesian = TRUE
         )
 
+        if (nrow(test_merge) > nrow(contact_data[[file]])) {
+          warning(
+            "Only ", nrow(contact_data[[file]]), " matching value",
+            ifelse(nrow(contact_data[[file]]) > 1, "s", ""), " in ",
+            paste0("'", common_id, "'", collapse = ", "),
+            " column", ifelse(length(common_id) > 1, "s", ""),
+            " when pulling ", basename(file), " into '", type, "' survey."
+          )
+        }
+
         if (nrow(test_merge) == nrow(main_surveys[[type]])) {
           ## check if all IDs can be merged in
           unique_main_survey_ids <-
             unique(main_surveys[[type]][, common_id, with = FALSE])
           unique_additional_survey_ids <-
             unique(contact_data[[file]][, common_id, with = FALSE])
-
-          id_overlap <- merge(
-            unique_main_survey_ids, unique_additional_survey_ids,
-            by = common_id
-          )
-
-          if (nrow(id_overlap) < nrow(unique_main_survey_ids)) {
-            warning(
-              ifelse(nrow(id_overlap) == 0, "No matching value",
-                     paste0(
-                       "Only ", nrow(id_overlap), " matching value",
-                       ifelse(nrow(id_overlap) > 1, "s", "")
-                     )), " in ",
-              paste0("'", common_id, "'", collapse = ", "),
-              " column", ifelse(length(common_id) > 1, "s", ""),
-              " when pulling ", basename(file), " into '", type, "' survey."
-            )
-          }
 
           id_overlap_y <- merge(
             unique_main_survey_ids, unique_additional_survey_ids, by = common_id,

--- a/R/load_survey.r
+++ b/R/load_survey.r
@@ -96,7 +96,8 @@ load_survey <- function(files, ...) {
             )
           }
 
-          ## check if all IDs can be merged in
+          ## check if file has additional rows that could not make it in the
+          ## merge
           unique_main_survey_ids <-
             unique(main_surveys[[type]][, common_id, with = FALSE])
           unique_additional_survey_ids <-

--- a/R/load_survey.r
+++ b/R/load_survey.r
@@ -24,7 +24,7 @@ load_survey <- function(files, ...) {
     )
   }
   survey_files <- grep("csv$", files, value = TRUE) # select csv files
-  reference_file <- grep("json$", files, value = TRUE) # select csv files
+  reference_file <- grep("json$", files, value = TRUE) # select json file
   reference <- fromJSON(reference_file)
 
   contact_data <- lapply(survey_files, function(x) {

--- a/R/load_survey.r
+++ b/R/load_survey.r
@@ -73,7 +73,7 @@ load_survey <- function(files, ...) {
     can_merge <- vapply(survey_files, function(x) {
       length(intersect(colnames(contact_data[[x]]), colnames(main_surveys[[type]]))) > 0
     }, TRUE)
-    merge_files <- names(can_merge[which(can_merge)])
+    merge_files <- names(can_merge[can_merge])
     while (length(merge_files) > 0) {
       merged_files <- NULL
       for (file in merge_files)
@@ -132,7 +132,7 @@ load_survey <- function(files, ...) {
       if (is.null(merged_files)) {
         merge_files <- NULL
       } else {
-        merge_files <- names(can_merge[which(can_merge)])
+        merge_files <- names(can_merge[can_merge])
       }
     }
   }

--- a/R/load_survey.r
+++ b/R/load_survey.r
@@ -15,7 +15,7 @@
 #' @export
 load_survey <- function(files, ...) {
 
-  exist <- vapply(files, file.exists, TRUE)
+  exist <- file.exists(files)
   missing <- files[!exist]
   if (length(missing) > 0) {
     stop(

--- a/R/load_survey.r
+++ b/R/load_survey.r
@@ -34,7 +34,6 @@ load_survey <- function(files, ...) {
 
   main_types <- c("participant", "contact")
   main_surveys <- list()
-  main_file <- c()
 
   ## first, get the common files
   for (type in main_types)

--- a/R/load_survey.r
+++ b/R/load_survey.r
@@ -80,7 +80,7 @@ load_survey <- function(files, ...) {
         common_id <- intersect(colnames(contact_data[[file]]), colnames(main_surveys[[type]]))
 
         # is the id unique and can the merge be done uniquely?
-        if (anyDuplicated(main_surveys[[type]][, common_id, with = FALSE]) == 0) {
+        if (anyDuplicated(contact_data[[file]][, common_id, with = FALSE]) == 0) {
           test_merge <- merge(
             main_surveys[[type]], contact_data[[file]], by = common_id,
             all.x = TRUE

--- a/R/load_survey.r
+++ b/R/load_survey.r
@@ -79,23 +79,23 @@ load_survey <- function(files, ...) {
       {
         common_id <- intersect(colnames(contact_data[[file]]), colnames(main_surveys[[type]]))
 
-        ## try a merge to see whether it can be done uniquely
-        test_merge <- merge(
-          main_surveys[[type]], contact_data[[file]], by = common_id,
-          all.x = TRUE, allow.cartesian = TRUE
-        )
-
-        if (nrow(test_merge) > nrow(contact_data[[file]])) {
-          warning(
-            "Only ", nrow(contact_data[[file]]), " matching value",
-            ifelse(nrow(contact_data[[file]]) > 1, "s", ""), " in ",
-            paste0("'", common_id, "'", collapse = ", "),
-            " column", ifelse(length(common_id) > 1, "s", ""),
-            " when pulling ", basename(file), " into '", type, "' survey."
+        # is the id unique and can the merge be done uniquely?
+        if (anyDuplicated(main_surveys[[type]][, common_id, with = FALSE]) == 0) {
+          test_merge <- merge(
+            main_surveys[[type]], contact_data[[file]], by = common_id,
+            all.x = TRUE
           )
-        }
 
-        if (nrow(test_merge) == nrow(main_surveys[[type]])) {
+          if (nrow(test_merge) > nrow(contact_data[[file]])) {
+            warning(
+              "Only ", nrow(contact_data[[file]]), " matching value",
+              ifelse(nrow(contact_data[[file]]) > 1, "s", ""), " in ",
+              paste0("'", common_id, "'", collapse = ", "),
+              " column", ifelse(length(common_id) > 1, "s", ""),
+              " when pulling ", basename(file), " into '", type, "' survey."
+            )
+          }
+
           ## check if all IDs can be merged in
           unique_main_survey_ids <-
             unique(main_surveys[[type]][, common_id, with = FALSE])


### PR DESCRIPTION
The following code was filling my entire RAM because of `allow.cartesian = TRUE`.

```r
f <- download_survey("https://doi.org/10.5281/zenodo.4790345")
load_survey(f)
```

This PR fixes that by checking if the merge can be done beforehand instead of trying to do it and then checking if all went well.
It also includes a couple of simplifications I did while I was trying to diagnostic this issue.