### PR TITLE
Customise backport_linter() to check declared R dep

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -22,6 +22,7 @@ jobs:
             any::gh
             any::lintr
             any::purrr
+            epiverse-trace/etdev
           needs: check
 
       - name: Add lintr options

--- a/.lintr
+++ b/.lintr
@@ -6,6 +6,8 @@ linters: linters_with_tags(
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
     function_argument_linter = NULL,
+    # Use minimum R declared in DESCRIPTION or fall back to current R version
+    backport_linter(if (length(x <- etdev::extract_min_r_version())) x else getRversion()),
     # Extra exclusions for socialmixr.
     # These exclusions should ideally be removed at some point.
     line_length_linter = NULL,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Provides methods for sampling contact matrices from diary
     et al. (2008) <doi:10.1371/journal.pmed.0050074>.
 License: MIT + file LICENSE
 Depends: 
-    R (>= 3.4.0)
+    R (>= 3.5.0)
 Imports: 
     countrycode,
     curl,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Provides methods for sampling contact matrices from diary
     et al. (2008) <doi:10.1371/journal.pmed.0050074>.
 License: MIT + file LICENSE
 Depends: 
-    R (>= 3.5.0)
+    R (>= 3.4.0)
 Imports: 
     countrycode,
     curl,


### PR DESCRIPTION
@sbfnk, do you remember why you bumped the minimum required R version to 3.5.0 in https://github.com/epiforecasts/socialmixr/commit/5a92b5067bc0b09d445e56424623811a1aed08b0?