### PR TITLE
Speed up tests.

### DIFF
--- a/R/clean.r
+++ b/R/clean.r
@@ -80,6 +80,7 @@ clean.survey <- function(x, country.column = "country", participant.age.column =
       is.na(..high),
       ..high := fifelse(is.na(..high), ..low, ..high)
     ]
+    seconds_in_year <- period_to_seconds(years(1))
     for (limit in limits) {
       x$participants <- x$participants[,
         paste(limit) := fifelse(!is.na(get(limit)), as.numeric(get(limit)), NA_real_)
@@ -88,7 +89,7 @@ clean.survey <- function(x, country.column = "country", participant.age.column =
         paste(limit) := fifelse(
           !is.na(get(limit)),
           period_to_seconds(period(get(limit), ..age.unit)) /
-            period_to_seconds(years(1)),
+            seconds_in_year,
           NA_real_
         ),
         by = seq_len(nrow(x$participants))

--- a/R/contact_matrix.r
+++ b/R/contact_matrix.r
@@ -60,7 +60,7 @@ contact_matrix <- function(survey, countries = NULL, survey.pop, age.limits, fil
   error_string <-
     "must be a survey object (created using `survey()` or `get_survey()`)"
 
-  if (all(is_doi(survey))) {
+  if (is_doi(survey)) {
     deprecate_warn(
       "0.3.2", paste0("contact_matrix(survey = '", error_string, "')"),
       details = "Passing a DOI will be removed in version 0.4.0."

--- a/R/download_survey.r
+++ b/R/download_survey.r
@@ -21,7 +21,7 @@
 #  @seealso load_survey
 #' @export
 download_survey <- function(survey, dir = NULL, sleep = 1) {
-  
+
   if (!is.character(survey) || length(survey) > 1) {
     stop("'survey' must be a character of length 1")
   }

--- a/R/download_survey.r
+++ b/R/download_survey.r
@@ -137,5 +137,5 @@ find_common_prefix <- function(vec) {
 ##' @return Logical; \code{TRUE} if \code{x} is a DOI, \code{FALSE} otherwise
 ##' @author Sebastian Funk
 is_doi <- function(x) {
-  grepl("^10.[0-9.]{4,}/[-._;()/:A-z0-9]+$", x)
+  is.character(x) && grepl("^10.[0-9.]{4,}/[-._;()/:A-z0-9]+$", x)
 }

--- a/R/download_survey.r
+++ b/R/download_survey.r
@@ -21,20 +21,21 @@
 #  @seealso load_survey
 #' @export
 download_survey <- function(survey, dir = NULL, sleep = 1) {
-  survey <- sub("^(https?:\\/\\/(dx\\.)?doi\\.org\\/|doi:)", "", survey)
-  survey <- sub("#.*$", "", survey)
-  is.doi <- (length(survey) > 0) && all(is_doi(survey))
-  is.url <- (length(survey) > 0) && (is.doi || grepl("^https?:\\/\\/", survey))
-
-  if (is.url && length(survey) > 1) {
-    stop("'survey' must be of length 1")
+  
+  if (!is.character(survey) || length(survey) > 1) {
+    stop("'survey' must be a character of length 1")
   }
 
-  if (is.doi) url <- paste0("https://doi.org/", survey) else url <- survey
+  survey <- sub("^(https?:\\/\\/(dx\\.)?doi\\.org\\/|doi:)", "", survey)
+  survey <- sub("#.*$", "", survey)
+  is.doi <- is_doi(survey)
+  is.url <- is.doi || grepl("^https?:\\/\\/", survey)
 
   if (!is.url) {
     stop("'survey' is not a DOI or URL.")
   }
+
+  if (is.doi) url <- paste0("https://doi.org/", survey) else url <- survey
 
   temp_body <- GET(
     url,
@@ -136,5 +137,5 @@ find_common_prefix <- function(vec) {
 ##' @return Logical; \code{TRUE} if \code{x} is a DOI, \code{FALSE} otherwise
 ##' @author Sebastian Funk
 is_doi <- function(x) {
-  is.character(x) && grepl("^10.[0-9.]{4,}/[-._;()/:A-z0-9]+$", x)
+  grepl("^10.[0-9.]{4,}/[-._;()/:A-z0-9]+$", x)
 }

--- a/R/download_survey.r
+++ b/R/download_survey.r
@@ -136,5 +136,5 @@ find_common_prefix <- function(vec) {
 ##' @return Logical; \code{TRUE} if \code{x} is a DOI, \code{FALSE} otherwise
 ##' @author Sebastian Funk
 is_doi <- function(x) {
-  is.character(x) & grepl("^10.[0-9.]{4,}/[-._;()/:A-z0-9]+$", x)
+  is.character(x) && grepl("^10.[0-9.]{4,}/[-._;()/:A-z0-9]+$", x)
 }

--- a/tests/testthat/test-matrix.r
+++ b/tests/testthat/test-matrix.r
@@ -389,6 +389,7 @@ test_that("The weights with threshold", {
 test_that("Country names in Zenodo datasets and the wpp package are aligned (e.g. Viet Nam vs. Vietnam)", {
   skip_if_offline("zenodo.org")
   skip_on_cran()
+  skip_on_ci()
   vietnam1 <- get_survey("https://doi.org/10.5281/zenodo.1289473")
   expect_length(suppressWarnings(contact_matrix(vietnam1, symmetric = FALSE)), 2) # no demography data used
   expect_length(suppressWarnings(contact_matrix(vietnam1, symmetric = TRUE)), 3) # country is recognized and demography data found
@@ -546,6 +547,9 @@ test_that("Contact matrices per capita are also generated when bootstrapping", {
 })
 
 test_that("passing a DOI for survey is deprecated", {
+  skip_if_offline("zenodo.org")
+  skip_on_cran()
+  skip_on_ci()
   lifecycle::expect_deprecated(
     contact_matrix(survey = "10.5281/zenodo.1095664") # nolint
   )


### PR DESCRIPTION
Fixes #112 

Commit messages indicate individual changes.

The `is_doi()` change leads to quite a substantial speedup which in and of itself should be enough to pass CRAN checks. Since `x & y()` seems to execute `y()` even if `x` is FALSE a lot of elements in large data frames were checked for being DOIs, which took its time.