### PR TITLE
remove missing population data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # socialmixr (development version)
 
 * The speed of loading surveys has been increased.
+* An error has been fixed causing NA contact matrices if any 5-year age band in the population data was missing.
 
 # socialmixr 0.3.2
 

--- a/R/contact_matrix.r
+++ b/R/contact_matrix.r
@@ -430,6 +430,8 @@ contact_matrix <- function(survey, countries = NULL, survey.pop, age.limits, fil
 
     # add upper.age.limit after sorting the survey.pop ages (and add maximum age > given ages)
     survey.pop <- survey.pop[order(lower.age.limit), ]
+    # if any lower age limits are missing remove them
+    survey.pop <- survey.pop[!is.na(population)]
     survey.pop$upper.age.limit <- unlist(c(
       survey.pop[-1, "lower.age.limit"],
       1 + max(


### PR DESCRIPTION
Fixes #120 

It doesn't fix the fact that without passing `survey.pop` population data from 1950 will be used.