### PR TITLE
don't plot in tests

### DIFF
--- a/tests/testthat/test-plot.r
+++ b/tests/testthat/test-plot.r
@@ -5,21 +5,31 @@ suppressWarnings({
 })
 
 test_that("contact matrix can be plotted", {
+  pdf(file = NULL)
   expect_no_error(matrix_plot(dta$matrix))
+  dev.off()
 })
 
 test_that("contact matrix per capita can be plotted", {
+  pdf(file = NULL)
   expect_no_error(matrix_plot(dta$matrix.per.capita))
+  dev.off()
 })
 
 test_that("contact matrix can be plotted with different color palette", {
+  pdf(file = NULL)
   expect_no_error(matrix_plot(dta$matrix, color.palette = rainbow))
+  dev.off()
 })
 
 test_that("contact matrix can be plotted with ad-hoc min and max values for the legend", {
+  pdf(file = NULL)
   expect_no_error(matrix_plot(dta$matrix, min.legend = 4, max.legend = 40))
+  dev.off()
 })
 
 test_that("contact matrix can be plotted with (ad-hoc) min and max values for the legend", {
+  pdf(file = NULL)
   expect_no_error(matrix_plot(dta$matrix, min.legend = 4, max.legend = 40))
+  dev.off()
 })


### PR DESCRIPTION
avoids actual plotting in tests, which can be annoying when testing locally