### PR TITLE
numeric artefact in symmetric matrices when sub-groups are unbalanced

### DIFF
--- a/R/contact_matrix.r
+++ b/R/contact_matrix.r
@@ -697,12 +697,11 @@ contact_matrix <- function(survey, countries = NULL, survey.pop, age.limits, fil
       normalised.weighted.matrix <- diag(survey.pop$population) %*% weighted.matrix
       normalised.weighted.matrix <- 0.5 * diag(1 / survey.pop$population) %*%
         (normalised.weighted.matrix + t(normalised.weighted.matrix))
-      
       # show warning if normalisation factors exceed the symmetric.norm.threshold
       normalisation_fctr <- c(normalised.weighted.matrix / weighted.matrix, weighted.matrix / normalised.weighted.matrix)
       normalisation_fctr <- normalisation_fctr[!is.infinite(normalisation_fctr) & !is.na(normalisation_fctr)]
       if (any(normalisation_fctr > symmetric.norm.threshold)) {
-        warning("Large differences in the size of the sub-populations with the current age breaks are likely to result in artefacts after making the matrix symmetric. Please reconsider the age breaks to obtain more equally sized sub-populations. Normalization factors: [", paste(round(range(normalisation_fctr, na.rm = TRUE), digits=1), collapse=";"), "]")
+        warning("Large differences in the size of the sub-populations with the current age breaks are likely to result in artefacts after making the matrix symmetric. Please reconsider the age breaks to obtain more equally sized sub-populations. Normalization factors: [", paste(round(range(normalisation_fctr, na.rm = TRUE), digits = 1), collapse = ";"), "]")
       }
       # update weighted.matrix
       weighted.matrix <- normalised.weighted.matrix

--- a/R/contact_matrix.r
+++ b/R/contact_matrix.r
@@ -19,7 +19,7 @@
 #' @param weigh.dayofweek whether to weigh social contacts data by the day of the week (weight (5/7 / N_week / N) for weekdays and (2/7 / N_weekend / N) for weekends)
 #' @param weigh.age whether to weigh social contacts data by the age of the participants (vs. the populations' age distribution)
 #' @param weight.threshold threshold value for the standardized weights before running an additional standardisation (default 'NA' = no cutoff)
-#' @param symmetric.normalisation.threshold threshold value for the normalization weights when `symmetric = TRUE` before showing a warning that that large differences in the size of the sub-populations are likely to result in artefacts when making the matrix symmetric (default 2).
+#' @param symmetric.norm.threshold threshold value for the normalization weights when `symmetric = TRUE` before showing a warning that that large differences in the size of the sub-populations are likely to result in artefacts when making the matrix symmetric (default 2).
 #' @param sample.all.age.groups what to do if sampling participants (with `sample.participants = TRUE`) fails to sample participants from one or more age groups; if FALSE (default), corresponding rows will be set to NA, if TRUE the sample will be discarded and a new one taken instead
 #' @param return.part.weights boolean to return the participant weights
 #' @param return.demography boolean to explicitly return demography data that corresponds to the survey data (default 'NA' = if demography data is requested by other function parameters)
@@ -36,7 +36,7 @@
 #' data(polymod)
 #' contact_matrix(polymod, countries = "United Kingdom", age.limits = c(0, 1, 5, 15))
 #' @author Sebastian Funk
-contact_matrix <- function(survey, countries = NULL, survey.pop, age.limits, filter, counts = FALSE, symmetric = FALSE, split = FALSE, sample.participants = FALSE, estimated.participant.age = c("mean", "sample", "missing"), estimated.contact.age = c("mean", "sample", "missing"), missing.participant.age = c("remove", "keep"), missing.contact.age = c("remove", "sample", "keep", "ignore"), weights = NULL, weigh.dayofweek = FALSE, weigh.age = FALSE, weight.threshold = NA, symmetric.normalisation.threshold = 2, sample.all.age.groups = FALSE, return.part.weights = FALSE, return.demography = NA, per.capita = FALSE, ...) {
+contact_matrix <- function(survey, countries = NULL, survey.pop, age.limits, filter, counts = FALSE, symmetric = FALSE, split = FALSE, sample.participants = FALSE, estimated.participant.age = c("mean", "sample", "missing"), estimated.contact.age = c("mean", "sample", "missing"), missing.participant.age = c("remove", "keep"), missing.contact.age = c("remove", "sample", "keep", "ignore"), weights = NULL, weigh.dayofweek = FALSE, weigh.age = FALSE, weight.threshold = NA, symmetric.norm.threshold = 2, sample.all.age.groups = FALSE, return.part.weights = FALSE, return.demography = NA, per.capita = FALSE, ...) {
   surveys <- c("participants", "contacts")
 
   dot.args <- list(...)
@@ -698,12 +698,11 @@ contact_matrix <- function(survey, countries = NULL, survey.pop, age.limits, fil
       normalised.weighted.matrix <- 0.5 * diag(1 / survey.pop$population) %*%
         (normalised.weighted.matrix + t(normalised.weighted.matrix))
       
-      # show warning if normalisation factors exceed the symmetric.normalisation.threshold
-      normalisation_fctr <- c(normalised.weighted.matrix / weighted.matrix, 
-                              weighted.matrix/normalised.weighted.matrix)
-      normalisation_fctr <- normalisation_fctr[!is.infinite(normalisation_fctr)]
-      if(any(normalisation_fctr > symmetric.normalisation.threshold)){
-        warning(paste0("Large differences in the size of the sub-populations with the current age breaks are likely to result in artefacts after making the matrix symmetric. Please reconsider the age breaks to obtain more equally sized sub-populations. Normalization factors: [", paste(round(range(normalisation_fctr,na.rm = TRUE), digits=1), collapse=";"), "]"))
+      # show warning if normalisation factors exceed the symmetric.norm.threshold
+      normalisation_fctr <- c(normalised.weighted.matrix / weighted.matrix, weighted.matrix / normalised.weighted.matrix)
+      normalisation_fctr <- normalisation_fctr[!is.infinite(normalisation_fctr) & !is.na(normalisation_fctr)]
+      if (any(normalisation_fctr > symmetric.norm.threshold)) {
+        warning("Large differences in the size of the sub-populations with the current age breaks are likely to result in artefacts after making the matrix symmetric. Please reconsider the age breaks to obtain more equally sized sub-populations. Normalization factors: [", paste(round(range(normalisation_fctr, na.rm = TRUE), digits=1), collapse=";"), "]")
       }
       # update weighted.matrix
       weighted.matrix <- normalised.weighted.matrix

--- a/R/contact_matrix.r
+++ b/R/contact_matrix.r
@@ -19,6 +19,7 @@
 #' @param weigh.dayofweek whether to weigh social contacts data by the day of the week (weight (5/7 / N_week / N) for weekdays and (2/7 / N_weekend / N) for weekends)
 #' @param weigh.age whether to weigh social contacts data by the age of the participants (vs. the populations' age distribution)
 #' @param weight.threshold threshold value for the standardized weights before running an additional standardisation (default 'NA' = no cutoff)
+#' @param symmetric.normalisation.threshold threshold value for the normalization weights when `symmetric = TRUE` before showing a warning that that large differences in the size of the sub-populations are likely to result in artefacts when making the matrix symmetric (default 2).
 #' @param sample.all.age.groups what to do if sampling participants (with `sample.participants = TRUE`) fails to sample participants from one or more age groups; if FALSE (default), corresponding rows will be set to NA, if TRUE the sample will be discarded and a new one taken instead
 #' @param return.part.weights boolean to return the participant weights
 #' @param return.demography boolean to explicitly return demography data that corresponds to the survey data (default 'NA' = if demography data is requested by other function parameters)
@@ -35,7 +36,7 @@
 #' data(polymod)
 #' contact_matrix(polymod, countries = "United Kingdom", age.limits = c(0, 1, 5, 15))
 #' @author Sebastian Funk
-contact_matrix <- function(survey, countries = NULL, survey.pop, age.limits, filter, counts = FALSE, symmetric = FALSE, split = FALSE, sample.participants = FALSE, estimated.participant.age = c("mean", "sample", "missing"), estimated.contact.age = c("mean", "sample", "missing"), missing.participant.age = c("remove", "keep"), missing.contact.age = c("remove", "sample", "keep", "ignore"), weights = NULL, weigh.dayofweek = FALSE, weigh.age = FALSE, weight.threshold = NA, sample.all.age.groups = FALSE, return.part.weights = FALSE, return.demography = NA, per.capita = FALSE, ...) {
+contact_matrix <- function(survey, countries = NULL, survey.pop, age.limits, filter, counts = FALSE, symmetric = FALSE, split = FALSE, sample.participants = FALSE, estimated.participant.age = c("mean", "sample", "missing"), estimated.contact.age = c("mean", "sample", "missing"), missing.participant.age = c("remove", "keep"), missing.contact.age = c("remove", "sample", "keep", "ignore"), weights = NULL, weigh.dayofweek = FALSE, weigh.age = FALSE, weight.threshold = NA, symmetric.normalisation.threshold = 2, sample.all.age.groups = FALSE, return.part.weights = FALSE, return.demography = NA, per.capita = FALSE, ...) {
   surveys <- c("participants", "contacts")
 
   dot.args <- list(...)
@@ -694,8 +695,18 @@ contact_matrix <- function(survey, countries = NULL, survey.pop, age.limits, fil
       ## set c_{ij} N_i and c_{ji} N_j (which should both be equal) to
       ## 0.5 * their sum; then c_{ij} is that sum / N_i
       normalised.weighted.matrix <- diag(survey.pop$population) %*% weighted.matrix
-      weighted.matrix <- 0.5 * diag(1 / survey.pop$population) %*%
+      normalised.weighted.matrix <- 0.5 * diag(1 / survey.pop$population) %*%
         (normalised.weighted.matrix + t(normalised.weighted.matrix))
+      
+      # show warning if normalisation factors exceed the symmetric.normalisation.threshold
+      normalisation_fctr <- c(normalised.weighted.matrix / weighted.matrix, 
+                              weighted.matrix/normalised.weighted.matrix)
+      normalisation_fctr <- normalisation_fctr[!is.infinite(normalisation_fctr)]
+      if(any(normalisation_fctr > symmetric.normalisation.threshold)){
+        warning(paste0("Large differences in the size of the sub-populations with the current age breaks are likely to result in artefacts after making the matrix symmetric. Please reconsider the age breaks to obtain more equally sized sub-populations. Normalization factors: [", paste(round(range(normalisation_fctr,na.rm = TRUE), digits=1), collapse=";"), "]"))
+      }
+      # update weighted.matrix
+      weighted.matrix <- normalised.weighted.matrix
     }
   }
 

--- a/man/contact_matrix.Rd
+++ b/man/contact_matrix.Rd
@@ -22,6 +22,7 @@ contact_matrix(
   weigh.dayofweek = FALSE,
   weigh.age = FALSE,
   weight.threshold = NA,
+  symmetric.normalisation.threshold = 2,
   sample.all.age.groups = FALSE,
   return.part.weights = FALSE,
   return.demography = NA,
@@ -63,6 +64,8 @@ contact_matrix(
 \item{weigh.age}{whether to weigh social contacts data by the age of the participants (vs. the populations' age distribution)}
 
 \item{weight.threshold}{threshold value for the standardized weights before running an additional standardisation (default 'NA' = no cutoff)}
+
+\item{symmetric.normalisation.threshold}{threshold value for the normalization weights when \code{symmetric = TRUE} before showing a warning that that large differences in the size of the sub-populations are likely to result in artefacts when making the matrix symmetric (default 2).}
 
 \item{sample.all.age.groups}{what to do if sampling participants (with \code{sample.participants = TRUE}) fails to sample participants from one or more age groups; if FALSE (default), corresponding rows will be set to NA, if TRUE the sample will be discarded and a new one taken instead}
 

--- a/man/contact_matrix.Rd
+++ b/man/contact_matrix.Rd
@@ -22,7 +22,7 @@ contact_matrix(
   weigh.dayofweek = FALSE,
   weigh.age = FALSE,
   weight.threshold = NA,
-  symmetric.normalisation.threshold = 2,
+  symmetric.norm.threshold = 2,
   sample.all.age.groups = FALSE,
   return.part.weights = FALSE,
   return.demography = NA,
@@ -65,7 +65,7 @@ contact_matrix(
 
 \item{weight.threshold}{threshold value for the standardized weights before running an additional standardisation (default 'NA' = no cutoff)}
 
-\item{symmetric.normalisation.threshold}{threshold value for the normalization weights when \code{symmetric = TRUE} before showing a warning that that large differences in the size of the sub-populations are likely to result in artefacts when making the matrix symmetric (default 2).}
+\item{symmetric.norm.threshold}{threshold value for the normalization weights when \code{symmetric = TRUE} before showing a warning that that large differences in the size of the sub-populations are likely to result in artefacts when making the matrix symmetric (default 2).}
 
 \item{sample.all.age.groups}{what to do if sampling participants (with \code{sample.participants = TRUE}) fails to sample participants from one or more age groups; if FALSE (default), corresponding rows will be set to NA, if TRUE the sample will be discarded and a new one taken instead}
 

--- a/tests/testthat/test-matrix.r
+++ b/tests/testthat/test-matrix.r
@@ -50,7 +50,7 @@ options <-
     test1 = list(survey = polymod, countries = "United Kingdom", counts = TRUE, weigh.dayofweek = TRUE, age.limits = seq(0, 80, by = 5), missing.contact.age = "remove"),
     test2 = list(survey = polymod2, age.limits = c(0, 5), weights = "added_weight", symmetric = TRUE, sample.participants = TRUE),
     test3 = list(survey = polymod, survey.pop = "Australia", countries = "GB", split = TRUE, filter = c(cnt_home = 1), age.limits = c(0, 5, 10), estimated.contact.age = "sample", symmetric = TRUE, missing.contact.age = "remove"),
-    test4 = list(survey = polymod8, missing.contact.age = "sample", symmetric = TRUE, age.limits = c(0, 5, 15))
+    test4 = list(survey = polymod8, missing.contact.age = "sample", symmetric = TRUE, age.limits = c(0, 5, 15), symmetric.norm.threshold = 4)
   )
 
 contacts <- suppressMessages(lapply(options, function(x) {
@@ -543,5 +543,5 @@ test_that("Contact matrices per capita are also generated when bootstrapping", {
 
 
 test_that("Symmetric contact matrices with large normalisation weights throw a warning", {
-  expect_warning(contact_matrix(survey = polymod, age.limits = c(0, 90),symmetric = TRUE), "artefacts after making the matrix symmetric")
+  expect_warning(contact_matrix(survey = polymod, age.limits = c(0, 90), symmetric = TRUE), "artefacts after making the matrix symmetric")
 })

--- a/tests/testthat/test-matrix.r
+++ b/tests/testthat/test-matrix.r
@@ -540,3 +540,8 @@ test_that("Contact matrices per capita are also generated when bootstrapping", {
     ), 2)
   })
 })
+
+
+test_that("Symmetric contact matrices with large normalisation weights throw a warning", {
+  expect_warning(contact_matrix(survey = polymod, age.limits = c(0, 90),symmetric = TRUE), "artefacts after making the matrix symmetric")
+})


### PR DESCRIPTION
Included a warning when the normalization weights to obtain a symmetric matrix exceed a threshold (default 2), as this can cause unexpected inflation or deflation of the contact rates. The root of this issue lies in sparse data and unbalanced sub-groups. 

See #145 