### PR TITLE
Resolved an issue that prevented multiple figure panels with contact matrix figures

### DIFF
--- a/R/matrix_plot.R
+++ b/R/matrix_plot.R
@@ -128,5 +128,5 @@ matrix_plot <- function(mij, min.legend = 0, max.legend = NA, num.digits = 2, nu
   axis(side = 4, mgp = c(3, 1, 0), las = 2)
 
   # restore original graphical parameters
-  par(old.par)
+  par(plt = old.par$plt, err = old.par$err)
 }


### PR DESCRIPTION
Resolved an issue that prevented multiple figure panels with contact matrix figures. Specifically, resetting the 'par' after adding the legend strip in the 'plot_matrix' function caused the frame to be cleared, as if drawing on a new device.

Fix for issue #167 