### PR TITLE
Fix for issue with missing.contact.age "sample" and age.limits > 0

### DIFF
--- a/R/contact_matrix.R
+++ b/R/contact_matrix.R
@@ -195,9 +195,12 @@ contact_matrix <- function(survey, countries = NULL, survey.pop, age.limits, fil
     # note: do nothing when "missing" is specified
   }
 
+  # remove contact ages below the age limit, before dealing with missing contact ages
+  survey$contacts <- survey$contacts[is.na(cnt_age) |
+                                       cnt_age >= min(age.limits), ]
+  
   if (missing.contact.age == "remove" &&
-    nrow(survey$contacts[is.na(cnt_age) |
-      cnt_age < min(age.limits)]) > 0) {
+    nrow(survey$contacts[is.na(cnt_age)]) > 0) {
     if (!missing.contact.age.set) {
       message(
         "Removing participants that have contacts without age information. ",
@@ -205,21 +208,20 @@ contact_matrix <- function(survey, countries = NULL, survey.pop, age.limits, fil
       )
     }
     missing.age.id <- survey$contacts[
-      is.na(cnt_age) | cnt_age < min(age.limits), part_id
+      is.na(cnt_age), part_id
     ]
     survey$participants <- survey$participants[!(part_id %in% missing.age.id)]
   }
 
   if (missing.contact.age == "ignore" &&
-    nrow(survey$contacts[is.na(cnt_age) | cnt_age < min(age.limits)]) > 0) {
+    nrow(survey$contacts[is.na(cnt_age)]) > 0) {
     if (!missing.contact.age.set) {
       message(
         "Ignore contacts without age information. ",
         "To change this behaviour, set the 'missing.contact.age' option"
       )
     }
-    survey$contacts <- survey$contacts[!is.na(cnt_age) &
-      cnt_age >= min(age.limits), ]
+    survey$contacts <- survey$contacts[!is.na(cnt_age), ]
   }
 
   ## check if any filters have been requested

--- a/R/contact_matrix.R
+++ b/R/contact_matrix.R
@@ -197,8 +197,8 @@ contact_matrix <- function(survey, countries = NULL, survey.pop, age.limits, fil
 
   # remove contact ages below the age limit, before dealing with missing contact ages
   survey$contacts <- survey$contacts[is.na(cnt_age) |
-                                       cnt_age >= min(age.limits), ]
-  
+    cnt_age >= min(age.limits), ]
+
   if (missing.contact.age == "remove" &&
     nrow(survey$contacts[is.na(cnt_age)]) > 0) {
     if (!missing.contact.age.set) {

--- a/tests/testthat/test-matrix.r
+++ b/tests/testthat/test-matrix.r
@@ -555,3 +555,14 @@ test_that("Contact matrices per capita are also generated when bootstrapping", {
 test_that("Symmetric contact matrices with large normalisation weights throw a warning", {
   expect_warning(contact_matrix(survey = polymod, age.limits = c(0, 90), symmetric = TRUE), "artefacts after making the matrix symmetric")
 })
+
+test_that("Contacts with an age below the age limits are excluded regardless of the missing.contact.age setting", {
+  expect_equal(ncol(contact_matrix(polymod,age.limits = c(10,50), missing.contact.age = 'remove')$matrix), 2)
+  expect_equal(ncol(contact_matrix(polymod,age.limits = c(10,50), missing.contact.age = 'sample')$matrix), 2)
+  expect_equal(ncol(contact_matrix(polymod,age.limits = c(10,50), missing.contact.age = 'keep')$matrix), 3) # extra column for ages outside age limits (= NA)
+  expect_equal(ncol(contact_matrix(polymod,age.limits = c(10,50), missing.contact.age = 'ignore')$matrix), 2)
+})
+
+
+
+

--- a/tests/testthat/test-matrix.r
+++ b/tests/testthat/test-matrix.r
@@ -557,12 +557,8 @@ test_that("Symmetric contact matrices with large normalisation weights throw a w
 })
 
 test_that("Contacts with an age below the age limits are excluded regardless of the missing.contact.age setting", {
-  expect_equal(ncol(contact_matrix(polymod,age.limits = c(10,50), missing.contact.age = 'remove')$matrix), 2)
-  expect_equal(ncol(contact_matrix(polymod,age.limits = c(10,50), missing.contact.age = 'sample')$matrix), 2)
-  expect_equal(ncol(contact_matrix(polymod,age.limits = c(10,50), missing.contact.age = 'keep')$matrix), 3) # extra column for ages outside age limits (= NA)
-  expect_equal(ncol(contact_matrix(polymod,age.limits = c(10,50), missing.contact.age = 'ignore')$matrix), 2)
+  expect_equal(ncol(contact_matrix(polymod, age.limits = c(10, 50), missing.contact.age = "remove")$matrix), 2)
+  expect_equal(ncol(contact_matrix(polymod, age.limits = c(10, 50), missing.contact.age = "sample")$matrix), 2)
+  expect_equal(ncol(contact_matrix(polymod, age.limits = c(10, 50), missing.contact.age = "keep")$matrix), 3) # extra column for ages outside age limits (= NA)
+  expect_equal(ncol(contact_matrix(polymod, age.limits = c(10, 50), missing.contact.age = "ignore")$matrix), 2)
 })
-
-
-
-


### PR DESCRIPTION
Make sure the selection of contact.ages above the age.limits is done once, and not for each option of the missing.contact.age. Included also a testthat case to double check.

Fix for #169  