### PR TITLE
Remove dev dependency on etdev package

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -25,7 +25,6 @@ jobs:
             any::gh
             any::lintr
             any::purrr
-            epiverse-trace/etdev
           needs: check
 
       - name: Add lintr options

--- a/.lintr
+++ b/.lintr
@@ -6,8 +6,7 @@ linters: linters_with_tags(
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
     function_argument_linter = NULL,
-    # Use minimum R declared in DESCRIPTION or fall back to current R version
-    backport_linter(if (length(x <- etdev::extract_min_r_version())) x else getRversion()),
+    backport_linter("3.5.0"),
     # Extra exclusions for socialmixr.
     # These exclusions should ideally be removed at some point.
     line_length_linter = NULL,

--- a/.lintr
+++ b/.lintr
@@ -3,7 +3,6 @@ linters: linters_with_tags(
     object_name_linter = NULL,
     undesirable_function_linter = NULL,
     implicit_integer_linter = NULL,
-    extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
     function_argument_linter = NULL,
     backport_linter("3.5.0"),


### PR DESCRIPTION
The goal is to deprecate and remove the etdev package since the maintenance capacity of Epiverse-TRACE is going to decrease in the coming months.