### PR TITLE
Implementing fixes for lintr

### DIFF
--- a/R/as_contact_survey.R
+++ b/R/as_contact_survey.R
@@ -47,19 +47,22 @@ as_contact_survey <- function(
     year = year.column
   )
 
-  walk(names(to_check), \(column) {
-    if (
-      !is.null(to_check[[column]]) &&
-        !(to_check[[column]] %in% colnames(x$participants))
-    ) {
-      cli::cli_abort(
-        "{.arg {column}} column {.val {to_check[[column]]}} does not exist
+  walk(
+    .x = names(to_check),
+    .f = function(column) {
+      if (
+        !is.null(to_check[[column]]) &&
+          !(to_check[[column]] %in% colnames(x$participants))
+      ) {
+        cli::cli_abort(
+          "{.arg {column}} column {.val {to_check[[column]]}} does not exist
         in the participant data frame."
-      )
-    } else {
-      setnames(x$participants, to_check[[column]], column)
+        )
+      } else {
+        setnames(x$participants, to_check[[column]], column)
+      }
     }
-  })
+  )
 
   if (is.null(x$reference)) {
     cli::cli_warn("No reference provided.")

--- a/R/as_contact_survey.R
+++ b/R/as_contact_survey.R
@@ -58,7 +58,7 @@ as_contact_survey <- function(
           "{.arg {column}} column {.val {to_check[[column]]}} does not exist
         in the participant data frame."
         )
-      } else {
+      } else if (!is.null(to_check[[column]])) {
         setnames(x$participants, to_check[[column]], column)
       }
     }

--- a/R/cite.R
+++ b/R/cite.R
@@ -23,7 +23,5 @@ get_citation <- function(x) {
     x$reference
   )
 
-  bref <- do.call(bibentry, ref)
-
-  bref
+  do.call(bibentry, ref)
 }

--- a/R/cite.R
+++ b/R/cite.R
@@ -25,5 +25,5 @@ get_citation <- function(x) {
 
   bref <- do.call(bibentry, ref)
 
-  return(bref)
+  bref
 }

--- a/R/contact_matrix.R
+++ b/R/contact_matrix.R
@@ -794,7 +794,9 @@ contact_matrix <- function(
         c(
           "{.code symmetric = TRUE} does not work with missing data; will \\
           not make matrix symmetric.",
-          "i" = "{warning.suggestion}" # nolint
+          # nolint start
+          "i" = "{warning.suggestion}"
+          # nolint end
         )
       )
     } else {

--- a/R/contact_matrix.R
+++ b/R/contact_matrix.R
@@ -189,7 +189,10 @@ contact_matrix <- function(
       cli::cli_inform(
         c(
           "Removing participants without age information.",
-          "i" = "To change this behaviour, set the {.code missing.participant.age} option."
+          # nolint start
+          "i" = "To change this behaviour, set the \\
+          {.code missing.participant.age} option."
+          # nolint end
         )
       )
     }
@@ -263,7 +266,9 @@ contact_matrix <- function(
       cli::cli_inform(
         c(
           "Removing participants that have contacts without age information.",
+          # nolint start
           "i" = "To change this behaviour, set the 'missing.contact.age' option."
+          # nolint end
         )
       )
     }
@@ -282,7 +287,9 @@ contact_matrix <- function(
       cli::cli_inform(
         c(
           "Ignore contacts without age information.",
+          # nolint start
           "i" = "To change this behaviour, set the 'missing.contact.age' option."
+          # nolint end
         )
       )
     }
@@ -370,23 +377,23 @@ contact_matrix <- function(
         ## survey population not given but countries requested from
         ## survey - get population data from those countries
         survey.countries <- countries
-      } else {
+      } else if ("country" %in% colnames(survey$participants)) {
         ## neither survey population nor country names given - try to
         ## guess country or countries surveyed from participant data
-        if ("country" %in% colnames(survey$participants)) {
-          survey.countries <- unique(survey$participants[, country])
-        } else {
-          cli::cli_warn(
-            c(
-              "No {.arg survey.pop} or {.arg countries} given, and no
+        survey.countries <- unique(survey$participants[, country])
+      } else {
+        cli::cli_warn(
+          c(
+            "No {.arg survey.pop} or {.arg countries} given, and no
               {.arg country} column found in the data.",
-              "i" = "I don't know which population this is from.",
-              "i" = "Assuming the survey is representative."
-            )
+            # nolint start
+            "i" = "I don't know which population this is from (assuming the \\
+              survey is representative)."
+            # nolint end
           )
-          survey.representative <- TRUE
-        }
-      }
+        )
+        survey.representative <- TRUE
+      } # where line 380 open brace should close
 
       if (!survey.representative) {
         ## get population data for countries from 'wpp' package
@@ -421,7 +428,9 @@ contact_matrix <- function(
           cli::cli_abort(
             c(
               "Could not find population data for {missing.countries}.",
+              # nolint start
               "i" = "Use {.fn wpp_countries} to get a list of country names."
+              # nolint end
             )
           )
         }
@@ -524,7 +533,9 @@ contact_matrix <- function(
         c(
           "{.code weigh.dayofweek} is {.val TRUE}, but no {.col dayofweek} \\
           column in the data.",
+          # nolint start
           "i" = "Will ignore."
+          # nolint end
         )
       )
     }
@@ -783,7 +794,7 @@ contact_matrix <- function(
         c(
           "{.code symmetric = TRUE} does not work with missing data; will \\
           not make matrix symmetric.",
-          "i" = "{warning.suggestion}"
+          "i" = "{warning.suggestion}" # nolint
         )
       )
     } else {
@@ -807,10 +818,12 @@ contact_matrix <- function(
             "Large differences in the size of the sub-populations with the \\
             current age breaks are likely to result in artefacts after making \\
             the matrix symmetric.",
-            "i" = "Please reconsider the age breaks to obtain more equally \\
+            "!" = "Please reconsider the age breaks to obtain more equally \\
             sized sub-populations.",
+            # nolint start
             "i" = "Normalization factors: [{round(range(normalisation_fctr, \\
             na.rm = TRUE), digits = 1)}]"
+            # nolint end
           )
         )
       }
@@ -830,7 +843,7 @@ contact_matrix <- function(
         c(
           "{.code split = TRUE} does not work with missing data; will not
           split contact.matrix.",
-          "i" = "{warning.suggestion}"
+          "i" = "{warning.suggestion}" # nolint
         )
       )
       ret[["mean.contacts"]] <- NA
@@ -845,16 +858,19 @@ contact_matrix <- function(
         sum(survey.pop$population)
       spectrum.matrix <- weighted.matrix
       spectrum.matrix[is.na(spectrum.matrix)] <- 0
-      spectrum <- as.numeric(eigen(spectrum.matrix, only.values = TRUE)$values[
+      spectrum_val <- as.numeric(eigen(
+        spectrum.matrix,
+        only.values = TRUE
+      )$values[
         1
       ])
       ret[["mean.contacts"]] <- mean.contacts
-      ret[["normalisation"]] <- spectrum / mean.contacts
+      ret[["normalisation"]] <- spectrum_val / mean.contacts
 
       age.proportions <- survey.pop$population / sum(survey.pop$population)
       weighted.matrix <-
         diag(1 / nb.contacts) %*% weighted.matrix %*% diag(1 / age.proportions)
-      nb.contacts <- nb.contacts / spectrum
+      nb.contacts <- nb.contacts / spectrum_val
       ret[["contacts"]] <- nb.contacts
     }
   }

--- a/R/contact_matrix.R
+++ b/R/contact_matrix.R
@@ -393,7 +393,7 @@ contact_matrix <- function(
           )
         )
         survey.representative <- TRUE
-      } # where line 380 open brace should close
+      }
 
       if (!survey.representative) {
         ## get population data for countries from 'wpp' package

--- a/R/download_survey.R
+++ b/R/download_survey.R
@@ -35,13 +35,13 @@ download_survey <- function(survey, dir = NULL, sleep = 1) {
   }
 
   if (is.doi) {
-    url <- paste0("https://doi.org/", survey)
+    survey_url <- paste0("https://doi.org/", survey)
   } else {
-    url <- survey
+    survey_url <- survey
   }
 
   temp_body <- GET(
-    url,
+    survey_url,
     config = config(
       followlocation = 1
     ),
@@ -56,8 +56,9 @@ download_survey <- function(survey, dir = NULL, sleep = 1) {
   if (http_error(temp_body)) {
     cli::cli_abort(
       c(
-        "Could not fetch the resource.",
-        "i" = "This could an issue with the website server or your own connection."
+        "Failed to fetch the requested resource",
+        "x" = "The website server returned an HTTP error", # nolint
+        "i" = "Check your connection or the server status" # nolint
       )
     )
   }
@@ -85,20 +86,20 @@ download_survey <- function(survey, dir = NULL, sleep = 1) {
     "href"
   )
 
-  data <- data.table(url = links)
+  zenodo_links <- data.table(url = links)
   ## only download csv files
-  data[, file_name := tolower(basename(url))]
+  zenodo_links[, file_name := tolower(basename(url))]
 
-  if (anyDuplicated(data$file_name) > 0) {
+  if (anyDuplicated(zenodo_links$file_name) > 0) {
     cli::cli_warn(
       c(
         "Zenodo repository contains files with names that only differ by case.",
-        "i" = "This will cause unpredictable behaviour on case-insensitive \\
+        "!" = "This will cause unpredictable behaviour on case-insensitive \\
         file systems.",
-        "i" = "Please contact the authors to get this fixed."
+        "i" = "Please contact the authors to get this fixed." # nolint
       )
     )
-    data <- data[!duplicated(file_name)]
+    zenodo_links <- zenodo_links[!duplicated(file_name)]
   }
 
   if (is.null(dir)) {
@@ -107,7 +108,7 @@ download_survey <- function(survey, dir = NULL, sleep = 1) {
 
   cli::cli_inform("Getting {parsed_cite$name}.")
 
-  lcs <- find_common_prefix(data$file_name)
+  lcs <- find_common_prefix(zenodo_links$file_name)
   reference_file_path <- file.path(dir, paste0(lcs, "reference.json"))
   reference_json <- toJSON(reference)
   write(reference_json, reference_file_path)
@@ -115,14 +116,14 @@ download_survey <- function(survey, dir = NULL, sleep = 1) {
   files <- c(
     reference_file_path,
     vapply(
-      seq_len(nrow(data)),
+      seq_len(nrow(zenodo_links)),
       function(i) {
-        url <- data[i, ]$url
-        temp <- file.path(dir, data[i, ]$file_name)
-        message("Downloading ", url)
+        zenodo_url <- zenodo_links[i, ]$url
+        temp <- file.path(dir, zenodo_links[i, ]$file_name)
+        message("Downloading ", zenodo_url)
         Sys.sleep(sleep)
-        dl <- curl_download(url, temp)
-        return(temp)
+        dl <- curl_download(zenodo_url, temp)
+        temp
       },
       ""
     )
@@ -134,19 +135,19 @@ download_survey <- function(survey, dir = NULL, sleep = 1) {
 find_common_prefix <- function(vec) {
   # find initial longest common subequence of file names
   i <- 1
-  end <- FALSE
+  finish <- FALSE
   lcs <- ""
-  while (!end) {
+  while (!finish) {
     initial_bits <- vapply(vec, substr, start = 1, stop = i, "x")
     if (length(unique(initial_bits)) > 1) {
-      end <- TRUE
+      finish <- TRUE
     } else {
       lcs <- unique(initial_bits)
       i <- i + 1
     }
   }
 
-  return(lcs)
+  lcs
 }
 
 ##' Checks if a character string is a DOI

--- a/R/get_survey.R
+++ b/R/get_survey.R
@@ -33,16 +33,14 @@ get_survey <- function(survey, clear_cache = FALSE, ...) {
 .get_survey <- function(survey, ...) {
   if (inherits(survey, "contact_survey")) {
     new_survey <- copy(survey)
+  } else if (is.character(survey)) {
+    files <- download_survey(survey)
+    new_survey <- load_survey(files)
   } else {
-    if (is.character(survey)) {
-      files <- download_survey(survey)
-      new_survey <- load_survey(files)
-    } else {
-      cli::cli_abort(
-        "{.arg survey} must be a {.cls contact_survey} object or character."
-      )
-    }
+    cli::cli_abort(
+      "{.arg survey} must be a {.cls contact_survey} object or character."
+    )
   }
 
-  return(new_survey)
+  new_survey
 }

--- a/R/lists.R
+++ b/R/lists.R
@@ -52,12 +52,12 @@ list_surveys <- function(clear_cache = FALSE) {
   record_list <- record_list[, .SD[1], by = common_doi]
   ## order by date
   setkey(record_list, date)
-  return(record_list[, list(
+  record_list[, list(
     date_added = date,
     title,
     creator,
     url = identifier.2
-  )])
+  )]
 }
 
 #' List all countries contained in a survey
@@ -99,5 +99,6 @@ wpp_countries <- function() {
       "country.name"
     ))
   found_countries <- found_countries[!is.na(found_countries)]
-  return(found_countries)
+
+  found_countries
 }

--- a/R/lists.R
+++ b/R/lists.R
@@ -98,7 +98,5 @@ wpp_countries <- function() {
       "un",
       "country.name"
     ))
-  found_countries <- found_countries[!is.na(found_countries)]
-
-  found_countries
+  found_countries[!is.na(found_countries)]
 }

--- a/R/load_survey.R
+++ b/R/load_survey.R
@@ -15,9 +15,9 @@
 #' @export
 load_survey <- function(files, ...) {
   exist <- file.exists(files)
-  missing <- files[!exist]
-  if (length(missing) > 0) {
-    cli::cli_abort("File{?s} {.file {missing}} not found.")
+  files_missing <- files[!exist]
+  if (length(files_missing) > 0) {
+    cli::cli_abort("File{?s} {.file {files_missing}} not found.")
   }
   survey_files <- grep("csv$", files, value = TRUE) # select csv files
   reference_file <- grep("json$", files, value = TRUE) # select json file
@@ -188,5 +188,5 @@ load_survey <- function(files, ...) {
     )
   }
 
-  return(new_survey)
+  new_survey
 }

--- a/R/matrix_plot.R
+++ b/R/matrix_plot.R
@@ -75,7 +75,7 @@ matrix_plot <- function(
   # get plot region for matrix and legend based on current graphical parameters
   # note: based on layout from fields::imagePlot
   char.size <- par()$cin[1] / par()$din[1] # get text character size
-  offset <- char.size * par()$mar[4] # space between legend and main plot
+  plot_offset <- char.size * par()$mar[4] # space between legend and main plot
 
   # set legends' plot region
   legend_plot_region <- par()$plt
@@ -92,13 +92,13 @@ matrix_plot <- function(
   main_plot_region <- par()$plt
   main_plot_region[2] <- min(
     main_plot_region[2],
-    legend_plot_region[1] - offset
+    legend_plot_region[1] - plot_offset
   )
 
   # defensive check for main and legends' plot region
   dp <- legend_plot_region[2] - legend_plot_region[1]
   legend_plot_region[1] <- min(
-    main_plot_region[2] + offset,
+    main_plot_region[2] + plot_offset,
     legend_plot_region[1]
   )
   legend_plot_region[2] <- legend_plot_region[1] + dp

--- a/R/pop_age.R
+++ b/R/pop_age.R
@@ -54,7 +54,9 @@ pop_age <- function(
       cli::cli_warn(
         c(
           "Not all age groups represented in population data (5-year age band).",
+          # nolint start
           "i" = "Linearly estimating age group sizes from the 5-year bands."
+          # nolint end
         )
       )
       ..original.upper.age.limit <- NULL

--- a/R/reduce_agegroups.R
+++ b/R/reduce_agegroups.R
@@ -12,5 +12,5 @@ reduce_agegroups <- function(x, limits) {
   int <- findInterval(x, sort(limits))
   ret[!is.na(int) & int > 0] <-
     limits[int[!is.na(int) & int > 0]]
-  return(ret)
+  ret
 }

--- a/R/wpp_age.R
+++ b/R/wpp_age.R
@@ -95,5 +95,5 @@ wpp_age <- function(countries, years) {
     pop <- pop[order(lower.age.limit), ] # sort by lower.age.limit
   }
 
-  return(as.data.frame(pop))
+  as.data.frame(pop)
 }

--- a/inst/dev/check_all_surveys.r
+++ b/inst/dev/check_all_surveys.r
@@ -1,14 +1,12 @@
-library("socialmixr")
-library("purrr")
-library("here")
+library(socialmixr)
+library(purrr)
+library(here)
 
 ## load list of survey files
 survey_files <- readRDS(here("surveys", "survey_files.rds"))
 
 ## define safe checking function
-safe_check <- safely(\(files) {
-  check(load_survey(files))
-})
+safe_check <- safely(\(files) check(load_survey(files)))
 
 ## check all surveys
 checks <- map(survey_files, safe_check)

--- a/inst/dev/dl_all_surveys.r
+++ b/inst/dev/dl_all_surveys.r
@@ -1,5 +1,5 @@
-library("socialmixr")
-library("here")
+library(socialmixr)
+library(here)
 
 ## list all surveys
 ls <- list_surveys()

--- a/tests/testthat/_snaps/matrix.md
+++ b/tests/testthat/_snaps/matrix.md
@@ -159,58 +159,19 @@
 
 # warning is thrown if day of week is asked to be weighed but not present
 
-    Code
-      tmp <- contact_matrix(survey = polymod3, weigh.dayofweek = TRUE)
-    Message
-      Removing participants without age information.
-      i To change this behaviour, set the `missing.participant.age` option.
-      Removing participants that have contacts without age information.
-      i To change this behaviour, set the 'missing.contact.age' option.
-    Condition
-      Warning:
-      `weigh.dayofweek` is "TRUE", but no `dayofweek` column in the data.
-      i Will ignore.
+    `weigh.dayofweek` is "TRUE", but no `dayofweek` column in the data.
+    i Will ignore.
 
 # nonsensical operations are warned about
 
-    Code
-      tmp <- contact_matrix(survey = polymod, counts = TRUE, split = TRUE,
-        age.limits = c(0, 5))
-    Message
-      Removing participants without age information.
-      i To change this behaviour, set the `missing.participant.age` option.
-      Removing participants that have contacts without age information.
-      i To change this behaviour, set the 'missing.contact.age' option.
-    Condition
-      Warning:
-      `split = TRUE` does not make sense with `counts = TRUE`; will not split the contact matrix.
+    `split = TRUE` does not make sense with `counts = TRUE`; will not split the contact matrix.
 
 ---
 
-    Code
-      tmp <- contact_matrix(survey = polymod, counts = TRUE, symmetric = TRUE,
-        age.limits = c(0, 5))
-    Message
-      Removing participants without age information.
-      i To change this behaviour, set the `missing.participant.age` option.
-      Removing participants that have contacts without age information.
-      i To change this behaviour, set the 'missing.contact.age' option.
-    Condition
-      Warning:
-      `symmetric = TRUE` does not make sense with `counts = TRUE`; will not make matrix symmetric.
+    `symmetric = TRUE` does not make sense with `counts = TRUE`; will not make matrix symmetric.
 
 # warning is thrown if it is assumed that the survey is representative
 
-    Code
-      tmp <- contact_matrix(survey = polymod4, symmetric = TRUE, age.limits = c(0, 5,
-        15))
-    Message
-      Removing participants without age information.
-      i To change this behaviour, set the `missing.participant.age` option.
-      Removing participants that have contacts without age information.
-      i To change this behaviour, set the 'missing.contact.age' option.
-    Condition
-      Warning:
-      No `survey.pop` or `countries` given, and no `country` column found in the data.
-      i I don't know which population this is from (assuming the survey is representative).
+    No `survey.pop` or `countries` given, and no `country` column found in the data.
+    i I don't know which population this is from (assuming the survey is representative).
 

--- a/tests/testthat/_snaps/matrix.md
+++ b/tests/testthat/_snaps/matrix.md
@@ -199,3 +199,18 @@
       Warning:
       `symmetric = TRUE` does not make sense with `counts = TRUE`; will not make matrix symmetric.
 
+# warning is thrown if it is assumed that the survey is representative
+
+    Code
+      tmp <- contact_matrix(survey = polymod4, symmetric = TRUE, age.limits = c(0, 5,
+        15))
+    Message
+      Removing participants without age information.
+      i To change this behaviour, set the `missing.participant.age` option.
+      Removing participants that have contacts without age information.
+      i To change this behaviour, set the 'missing.contact.age' option.
+    Condition
+      Warning:
+      No `survey.pop` or `countries` given, and no `country` column found in the data.
+      i I don't know which population this is from (assuming the survey is representative).
+

--- a/tests/testthat/test-as_contact_survey.r
+++ b/tests/testthat/test-as_contact_survey.r
@@ -1,4 +1,4 @@
-library("data.table")
+library(data.table)
 
 erroneous_survey <-
   new_contact_survey(polymod$participants, polymod$contacts, polymod$reference)

--- a/tests/testthat/test-matrix.r
+++ b/tests/testthat/test-matrix.r
@@ -198,8 +198,8 @@ test_that("warning is thrown if population needed but no 'year' column present",
 })
 
 test_that("warning is thrown if day of week is asked to be weighed but not present", {
-  expect_snapshot(
-    tmp <- contact_matrix(survey = polymod3, weigh.dayofweek = TRUE) #nolint
+  expect_snapshot_warning(
+    contact_matrix(survey = polymod3, weigh.dayofweek = TRUE)
   )
 })
 
@@ -260,25 +260,21 @@ test_that("good suggestions are made", {
 })
 
 test_that("nonsensical operations are warned about", {
-  expect_snapshot(
-    # nolint start
-    tmp <- contact_matrix(
+  expect_snapshot_warning(
+    contact_matrix(
       survey = polymod,
       counts = TRUE,
       split = TRUE,
       age.limits = c(0, 5)
     )
-    # nolint end
   )
-  expect_snapshot(
-    # nolint start
-    tmp <- contact_matrix(
+  expect_snapshot_warning(
+    contact_matrix(
       survey = polymod,
       counts = TRUE,
       symmetric = TRUE,
       age.limits = c(0, 5)
     )
-    # nolint end
   )
   expect_warning(
     contact_matrix(
@@ -292,14 +288,12 @@ test_that("nonsensical operations are warned about", {
 })
 
 test_that("warning is thrown if it is assumed that the survey is representative", {
-  expect_snapshot(
-    # nolint start
-    tmp <- contact_matrix(
+  expect_snapshot_warning(
+    contact_matrix(
       survey = polymod4,
       symmetric = TRUE,
       age.limits = c(0, 5, 15)
     )
-    # nolint end
   )
 })
 

--- a/tests/testthat/test-matrix.r
+++ b/tests/testthat/test-matrix.r
@@ -199,7 +199,7 @@ test_that("warning is thrown if population needed but no 'year' column present",
 
 test_that("warning is thrown if day of week is asked to be weighed but not present", {
   expect_snapshot(
-    tmp <- contact_matrix(survey = polymod3, weigh.dayofweek = TRUE),
+    tmp <- contact_matrix(survey = polymod3, weigh.dayofweek = TRUE) #nolint
   )
 })
 
@@ -261,20 +261,24 @@ test_that("good suggestions are made", {
 
 test_that("nonsensical operations are warned about", {
   expect_snapshot(
+    # nolint start
     tmp <- contact_matrix(
       survey = polymod,
       counts = TRUE,
       split = TRUE,
       age.limits = c(0, 5)
     )
+    # nolint end
   )
   expect_snapshot(
+    # nolint start
     tmp <- contact_matrix(
       survey = polymod,
       counts = TRUE,
       symmetric = TRUE,
       age.limits = c(0, 5)
     )
+    # nolint end
   )
   expect_warning(
     contact_matrix(
@@ -288,13 +292,14 @@ test_that("nonsensical operations are warned about", {
 })
 
 test_that("warning is thrown if it is assumed that the survey is representative", {
-  expect_warning(
-    contact_matrix(
+  expect_snapshot(
+    # nolint start
+    tmp <- contact_matrix(
       survey = polymod4,
       symmetric = TRUE,
       age.limits = c(0, 5, 15)
-    ),
-    "Assuming the survey is representative"
+    )
+    # nolint end
   )
 })
 

--- a/tests/testthat/test-surveys.r
+++ b/tests/testthat/test-surveys.r
@@ -28,7 +28,7 @@ test_that("missing surveys can't be cited", {
 
 test_that("multiple DOI's cannot be loaded", {
   expect_error(suppressMessages(suppressWarnings(get_survey(c(
-    "10.5281/zenodo.1095664",
-    "10.5281/zenodo.1127693"
-  ))))) # nolint
+    "10.5281/zenodo.1095664", # nolint
+    "10.5281/zenodo.1127693" # nolint
+  )))))
 })

--- a/vignettes/intro.qmd
+++ b/vignettes/intro.qmd
@@ -16,9 +16,9 @@ date: "`r Sys.Date()`"
 ---
 
 ```{r setup, include = FALSE}
-library("knitr")
-library("socialmixr")
-library("ggplot2")
+library(knitr)
+library(socialmixr)
+library(ggplot2)
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
@@ -266,7 +266,7 @@ P_day.of.week <- c(5 / 7, 2 / 7) * 3000
 This survey data results in an unweighted average number of contacts:
 
 ```{r, echo=FALSE}
-print(paste("unweighted average number of contacts:", round(mean(survey_data$m_i), digits = 2)))
+cat(paste("unweighted average number of contacts:", round(mean(survey_data$m_i), digits = 2)))
 ```
 
 and age-specific unweighted averages on the number of contacts:
@@ -319,7 +319,7 @@ kable(survey_data)
 # remove the weighted number of contacts
 survey_data$`m_i * w_tilde` <- NULL
 
-print(paste("weighted average number of contacts:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
+cat(paste("weighted average number of contacts:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
 ```
 
 If the population-based weights are directly used in age-specific groups, the contact behavior of the 3 year-old participant, which participated during week day, is inflated due to the under-representation of week days in the survey sample. In addition, the number of contacts for 1 year-old participants is decreased because of the over-representation of weekend days in the survey. Using the population-weights within the two aggregated age groups, we obtain a more intuitive weighting for age group A, but it is still skewed for individuals in age group B. As such, this weighted average for age group B has no meaning in terms of social contact behavior:
@@ -380,7 +380,7 @@ survey_data[, -(1:4)] <- round(survey_data[, -(1:4)], digits = 2)
 # print
 kable(survey_data)
 
-print(paste("weighted average number of contacts:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
+cat(paste("weighted average number of contacts:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
 ```
 
 If the age-specific weights are directly used within the age groups, the contact behavior for age group B is inflated to unrealistic levels and the number of contacts for age group A is artificially low:
@@ -436,8 +436,8 @@ survey_data$w_tilde <- survey_data$w / sum(survey_data$w) * N
 survey_data[, -(1:4)] <- round(survey_data[, -(1:4)], digits = 2)
 kable(survey_data)
 
-print(paste("unweighted average number of contacts:", round(mean(survey_data$m_i), digits = 2)))
-print(paste("weighted average number of contacts:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
+cat(paste("unweighted average number of contacts:", round(mean(survey_data$m_i), digits = 2)))
+cat(paste("weighted average number of contacts:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
 ```
 
 The single participant of 3 years of age has a very large influence on the weighted population average. As such, we propose to truncate the relative age-specific weights $w$ at 3. As such, the weighted population average equals:
@@ -449,7 +449,7 @@ survey_data$w_tilde[survey_data$w_tilde > 3] <- 3
 ```{r, echo=FALSE}
 survey_data$w_tilde[survey_data$w_tilde > 3] <- 3
 
-print(paste("weighted average number of contacts after truncation:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
+cat(paste("weighted average number of contacts after truncation:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
 ```
 
 # Plotting

--- a/vignettes/socialmixr.Rmd
+++ b/vignettes/socialmixr.Rmd
@@ -15,9 +15,9 @@ vignette: >
 ---
 
 ```{r setup, include = FALSE}
-library("knitr")
-library("socialmixr")
-library("ggplot2")
+library(knitr)
+library(socialmixr)
+library(ggplot2)
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
@@ -265,7 +265,7 @@ P_day.of.week <- c(5 / 7, 2 / 7) * 3000
 This survey data results in an unweighted average number of contacts:
 
 ```{r, echo=FALSE}
-print(paste("unweighted average number of contacts:", round(mean(survey_data$m_i), digits = 2)))
+cat(paste("unweighted average number of contacts:", round(mean(survey_data$m_i), digits = 2)))
 ```
 
 and age-specific unweighted averages on the number of contacts:
@@ -318,7 +318,7 @@ kable(survey_data)
 # remove the weighted number of contacts
 survey_data$`m_i * w_tilde` <- NULL
 
-print(paste("weighted average number of contacts:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
+cat(paste("weighted average number of contacts:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
 ```
 
 If the population-based weights are directly used in age-specific groups, the contact behavior of the 3 year-old participant, which participated during week day, is inflated due to the under-representation of week days in the survey sample. In addition, the number of contacts for 1 year-old participants is decreased because of the over-representation of weekend days in the survey. Using the population-weights within the two aggregated age groups, we obtain a more intuitive weighting for age group A, but it is still skewed for individuals in age group B. As such, this weighted average for age group B has no meaning in terms of social contact behavior:
@@ -379,7 +379,7 @@ survey_data[, -(1:4)] <- round(survey_data[, -(1:4)], digits = 2)
 # print
 kable(survey_data)
 
-print(paste("weighted average number of contacts:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
+cat(paste("weighted average number of contacts:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
 ```
 
 If the age-specific weights are directly used within the age groups, the contact behavior for age group B is inflated to unrealistic levels and the number of contacts for age group A is artificially low:
@@ -435,8 +435,8 @@ survey_data$w_tilde <- survey_data$w / sum(survey_data$w) * N
 survey_data[, -(1:4)] <- round(survey_data[, -(1:4)], digits = 2)
 kable(survey_data)
 
-print(paste("unweighted average number of contacts:", round(mean(survey_data$m_i), digits = 2)))
-print(paste("weighted average number of contacts:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
+cat(paste("unweighted average number of contacts:", round(mean(survey_data$m_i), digits = 2)))
+cat(paste("weighted average number of contacts:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
 ```
 
 The single participant of 3 years of age has a very large influence on the weighted population average. As such, we propose to truncate the relative age-specific weights $w$ at 3. As such, the weighted population average equals:
@@ -448,7 +448,7 @@ survey_data$w_tilde[survey_data$w_tilde > 3] <- 3
 ```{r, echo=FALSE}
 survey_data$w_tilde[survey_data$w_tilde > 3] <- 3
 
-print(paste("weighted average number of contacts after truncation:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
+cat(paste("weighted average number of contacts after truncation:", round(mean(survey_data$m_i * survey_data$w_tilde), digits = 2)))
 ```
 
 # Plotting


### PR DESCRIPTION
Resolves #185 

- skip some lines e.g., `"i" = ` in `cli`, and assigning inside tests for snapshot tests as we just want the warning
- many various other fixes from suggestions from lintr :)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved code readability by renaming variables for clarity and updating function return styles to use implicit returns.
  * Added or adjusted linter suppression comments to reduce unnecessary warnings in code and tests.
  * Updated library loading calls to use unquoted package names for consistency.

* **Documentation**
  * Enhanced vignettes by replacing print statements with cat for cleaner output display.

* **Tests**
  * Added a new test snapshot for warning conditions in contact matrix calculations.
  * Updated linter suppression comments in test files for improved code quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->