### PR TITLE
don't follow alternate links

### DIFF
--- a/R/download_survey.R
+++ b/R/download_survey.R
@@ -100,7 +100,10 @@ download_survey <- function(survey, dir = NULL, sleep = 1) {
   reference[[ifelse(is.doi, "doi", "url")]] <- survey
 
   links <- xml_attr(
-    xml_find_all(parsed_body, "//link[@type=\"text/csv\" and not(@rel=\"alternate\")]"),
+    xml_find_all(
+      parsed_body,
+      "//link[@type=\"text/csv\" and not(@rel=\"alternate\")]"
+    ),
     "href"
   )
 


### PR DESCRIPTION
when investigating #222 I noticed that duplicate files were reported even though they did not exist - turns out that is because Zenodo reports the same link as "item" and "alternate" links. This PR filters these to not be the "alternate" versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined survey CSV download selection to exclude alternate link formats, ensuring the correct file is retrieved during download operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->