### PR TITLE
Fix convert_factor_to_integer() to return NA for non-numeric levels

### DIFF
--- a/R/contact-matrix-utils.R
+++ b/R/contact-matrix-utils.R
@@ -289,15 +289,12 @@ convert_factor_to_integer <- function(
   factor_cols <- intersect(cols, names(data)[which_factors])
   data[,
     (factor_cols) := lapply(.SD, function(x) {
-      # Try converting factor levels to integers, suppressing warnings
+      # Convert factor levels to integers - non-numeric levels become NA
       num_levels <- suppressWarnings(as.integer(levels(x)))
-      # If any level failed to parse (i.e. non-numeric), warn and fall back
+      # Warn if any level failed to parse (i.e. non-numeric)
       if (any(is.na(num_levels) & !is.na(levels(x)))) {
-        cli::cli_warn("Non-numeric factor levels found in column")
-        # as.integer(x) returns the internal factor codes
-        return(as.integer(x))
+        cli::cli_warn("Non-numeric factor levels found; these will become NA")
       }
-      # Otherwise map each value to its numeric level
       num_levels[x]
     }),
     .SDcols = factor_cols

--- a/tests/testthat/test-convert-factor-to-integer.R
+++ b/tests/testthat/test-convert-factor-to-integer.R
@@ -1,0 +1,56 @@
+test_that("convert_factor_to_integer preserves numeric values from factor levels", {
+  dt <- data.table::data.table(
+    age = factor(c(3, 4, 6, 3))
+  )
+
+  result <- convert_factor_to_integer(dt, cols = "age")
+
+  # Should be 3, 4, 6, 3 - not 1, 2, 3, 1 (factor codes)
+  expect_identical(result$age, c(3L, 4L, 6L, 3L))
+})
+
+test_that("convert_factor_to_integer handles non-sequential numeric levels", {
+  dt <- data.table::data.table(
+    age = factor(c(10, 20, 30, 10))
+  )
+
+  result <- convert_factor_to_integer(dt, cols = "age")
+
+  expect_identical(result$age, c(10L, 20L, 30L, 10L))
+})
+
+test_that("convert_factor_to_integer returns NA for non-numeric levels", {
+  dt <- data.table::data.table(
+    age = factor(c("3", "4", "five", "6"))
+  )
+
+  expect_warning(
+    convert_factor_to_integer(dt, cols = "age"),
+    "Non-numeric factor levels"
+  )
+
+  # Non-numeric "five" should become NA, others preserved
+  expect_identical(dt$age, c(3L, 4L, NA_integer_, 6L))
+})
+
+test_that("convert_factor_to_integer only converts specified columns", {
+  dt <- data.table::data.table(
+    age = factor(c(10, 20, 30)),
+    group = factor(c("a", "b", "c"))
+  )
+
+  result <- convert_factor_to_integer(dt, cols = "age")
+
+  expect_identical(result$age, c(10L, 20L, 30L))
+  expect_s3_class(result$group, "factor") # group should remain a factor
+})
+
+test_that("convert_factor_to_integer ignores non-factor columns", {
+  dt <- data.table::data.table(
+    age = c(10L, 20L, 30L) # already integer
+  )
+
+  result <- convert_factor_to_integer(dt, cols = "age")
+
+  expect_identical(result$age, c(10L, 20L, 30L))
+})


### PR DESCRIPTION
## Summary

Fixed `convert_factor_to_integer()` to properly return `NA` for non-numeric factor levels instead of returning factor codes.

Fixes #229

## Details

Previously, when a factor had non-numeric levels like `factor(c(3, 4, "five", 6))`, the function would fall back to returning factor codes `c(1, 2, 4, 3)`. Now it correctly returns `c(3, 4, NA, 6)` - preserving the numeric values and using `NA` for non-parseable levels.

The function still warns when non-numeric levels are encountered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved factor-to-integer conversion behavior to map factor levels to integers. Non-numeric levels now return NA with a warning instead of using internal codes for more predictable results.

* **Tests**
  * Added comprehensive test coverage for factor conversion functionality, including handling of numeric and non-numeric levels, selective column conversion, and preservation of non-factor columns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->