### PR TITLE
Reduce verbosity by removing messages about removing participants/contacts with missing ages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `as_contact_survey()` no longer requires `country` and `year` columns. These columns are now auto-detected if present, but surveys without them can be loaded successfully (#193, #199).
 
+* Reduced verbosity by removing messages about removing participants/contacts with missing ages (#228).
+
 ## Breaking changes
 
 * When `age.limits` is not specified, it is now inferred from both participant and contact ages, not just participant ages. This may result in more age groups if contacts include ages beyond the participant age range (#230).

--- a/R/contact-matrix-utils.R
+++ b/R/contact-matrix-utils.R
@@ -134,15 +134,6 @@ impute_contact_ages <- function(
 #' @autoglobal
 drop_missing_contact_ages <- function(contacts, missing_action) {
   if (missing_action == "ignore" && nrow(contacts[is.na(cnt_age)]) > 0) {
-    cli::cli_inform(
-      c(
-        "Ignore contacts without age information.",
-        # nolint start
-        "i" = "To change this behaviour, set the \\
-          {.code missing.contact.age} option."
-        # nolint end
-      )
-    )
     contacts <- contacts[!is.na(cnt_age), ]
   }
   contacts
@@ -243,15 +234,6 @@ drop_invalid_ages <- function(
   ppt_no_age_info <- participants[is.na(part_age) | part_age < min(age_limits)]
   no_age_info <- nrow(ppt_no_age_info) > 0
   if (missing_action == "remove" && no_age_info) {
-    cli::cli_inform(
-      message = c(
-        "Removing participants without age information.",
-        # nolint start
-        "i" = "To change this behaviour, set the \\
-          {.code missing.participant.age} option."
-        # nolint end
-      )
-    )
     participants <- participants[!is.na(part_age) & part_age >= min(age_limits)]
   }
   participants
@@ -264,15 +246,6 @@ drop_invalid_contact_ages <- function(
   missing_action
 ) {
   if (missing_action == "remove" && nrow(contacts[is.na(cnt_age)]) > 0) {
-    cli::cli_inform(
-      c(
-        "Removing participants that have contacts without age information.",
-        # nolint start
-        "i" = "To change this behaviour, set the \\
-          {.code missing.contact.age} option."
-        # nolint end
-      )
-    )
     missing.age.id <- contacts[is.na(cnt_age), part_id]
     participants <- participants[!(part_id %in% missing.age.id)]
   }

--- a/tests/testthat/_snaps/matrix.md
+++ b/tests/testthat/_snaps/matrix.md
@@ -235,11 +235,6 @@
 
     Code
       contact_matrix(survey = polymod5, symmetric = TRUE)
-    Message
-      Removing participants without age information.
-      i To change this behaviour, set the `missing.participant.age` option.
-      Removing participants that have contacts without age information.
-      i To change this behaviour, set the `missing.contact.age` option.
     Condition
       Error in `survey_pop_from_countries()`:
       ! Could not find population data for: "Zamonia".
@@ -284,11 +279,6 @@
     Code
       contact_matrix(survey = polymod, counts = TRUE, symmetric = TRUE, age.limits = c(
         0, 5))
-    Message
-      Removing participants without age information.
-      i To change this behaviour, set the `missing.participant.age` option.
-      Removing participants that have contacts without age information.
-      i To change this behaviour, set the `missing.contact.age` option.
     Condition
       Warning in `contact_matrix()`:
       `symmetric = TRUE` does not make sense with `counts = TRUE`; will not make matrix symmetric.
@@ -331,11 +321,6 @@
     Code
       contact_matrix(polymod_nocountry, age.limits = c(0, 18, 60), symmetric = TRUE,
       survey.pop = "dummy")
-    Message
-      Removing participants without age information.
-      i To change this behaviour, set the `missing.participant.age` option.
-      Removing participants that have contacts without age information.
-      i To change this behaviour, set the `missing.contact.age` option.
     Condition
       Error in `survey_pop_from_countries()`:
       ! Could not find population data for: "dummy".

--- a/tests/testthat/test-matrix.r
+++ b/tests/testthat/test-matrix.r
@@ -285,10 +285,6 @@ test_that("warning is thrown if participant data has no country", {
   expect_warning(check(x = polymod4), "does not exist")
 })
 
-test_that("user is informed about removing missing data", {
-  expect_message(contact_matrix(survey = polymod), "Removing")
-})
-
 test_that("check result is reported back", {
   withr::local_options(lifecycle_verbosity = "quiet")
   expect_snapshot(check(x = polymod2))


### PR DESCRIPTION
Fixes #228

Removes three `cli_inform` messages that were displayed every time `contact_matrix()` was called with default settings:

- "Ignore contacts without age information" from `drop_missing_contact_ages()`
- "Removing participants without age information" from `drop_invalid_ages()`
- "Removing participants that have contacts without age information" from `drop_invalid_contact_ages()`

These messages were excessive as they appeared on every typical usage. Users who want to see all diagnostic output can still use other mechanisms, and warnings/errors for actual problems are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated to reflect reduction in informational messages during data processing operations.

* **Tests**
  * Updated test snapshots and assertions to align with simplified output messaging behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->