### PR TITLE
Fix pop_age() to use pop_column parameter in interpolation

### DIFF
--- a/R/pop_age.R
+++ b/R/pop_age.R
@@ -112,8 +112,8 @@ pop_age <- function(
       pop <- pop[, ..upper.age.limit := c(pop[[pop_age_column]][-1], NA)]
       pop[
         !is.na(..original.upper.age.limit),
-        population := round(
-          population *
+        paste(pop_column) := round(
+          get(pop_column) *
             (..upper.age.limit - get(pop_age_column)) /
             (..original.upper.age.limit - ..original.lower.age.limit)
         )

--- a/tests/testthat/test-agegroups.r
+++ b/tests/testthat/test-agegroups.r
@@ -53,6 +53,31 @@ test_that("pop_age doesn't change total population size", {
   )
 })
 
+test_that("pop_age works with custom column names and interpolation", {
+  # Create test data with non-standard column names
+  pop_data <- data.frame(
+    age_lower = c(0, 5, 10, 15, 20),
+    pop_count = c(1000, 1200, 1100, 900, 800)
+  )
+
+  # Test with interpolation (age_limits not matching existing groups)
+  # nolint start: implicit_assignment_linter
+  result <- suppressWarnings(
+    pop_age(
+      pop_data,
+      age_limits = c(0, 8, 15),
+      pop_age_column = "age_lower",
+      pop_column = "pop_count"
+    )
+  )
+  # nolint end
+
+  expect_named(result, c("age_lower", "pop_count"))
+  expect_identical(result$age_lower, c(0, 8, 15))
+  # Total population should be preserved
+  expect_identical(sum(result$pop_count), sum(pop_data$pop_count))
+})
+
 test_that("pop_age throws warnings or errors", {
   expect_snapshot(
     error = TRUE,


### PR DESCRIPTION
## Summary

- Fixes hard-coded `population` column in interpolation code to use the `pop_column` parameter
- Line 115: `population :=` → `paste(pop_column) :=`
- Line 116: `population *` → `get(pop_column) *`
- Adds test for custom column names with interpolation

Fixes #267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Population column handling now supports custom column names while preserving data interpolation logic.

* **Tests**
  * Added test coverage for custom column names and interpolation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->